### PR TITLE
Feat: ProjectList DataLoad-Logic Add

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",
+        "fs": "^0.0.1-security",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^6.26.0",
@@ -4749,6 +4750,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",
+    "fs": "^0.0.1-security",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^6.26.0",

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,5 +1,6 @@
-const { app, BrowserWindow } = require("electron");
+const { app, BrowserWindow, ipcMain } = require("electron");
 const path = require("node:path");
+const fs = require("fs");
 
 if (require("electron-squirrel-startup")) {
   app.quit();
@@ -11,7 +12,9 @@ const createWindow = () => {
     height: 600,
     webPreferences: {
       preload: path.join(__dirname, "preload.js")
-    }
+    },
+    contextIsolation: true,
+    nodeIntegration: false
   });
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
@@ -38,5 +41,15 @@ app.whenReady().then(() => {
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
+  }
+});
+
+ipcMain.handle("get-project-list", async (_, path) => {
+  try {
+    const data = fs.readFileSync(path, "utf-8");
+    const projectData = JSON.parse(data);
+    return projectData;
+  } catch (error) {
+    console.error(error);
   }
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,2 +1,5 @@
-// See the Electron documentation for details on how to use preload scripts:
-// https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("api", {
+  loadProjectList: path => ipcRenderer.invoke("get-project-list", path)
+});

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -1,10 +1,29 @@
+import { useEffect } from "react";
 import { PageContentContainer } from "@public/style/Project.styles";
 import { useNavigation } from "@utils/common";
 import icons from "@public/images";
-import mockData from "@utils/mockData.json";
+import useUIStore from "@/store/uiStore";
+import useProjectStore from "@/store/projectStore";
 
-const ProjectList = ({ showModal }) => {
+const ProjectList = () => {
+  const { showModal } = useUIStore();
+  const { projects, setProjects, checkProjectPath } = useProjectStore();
   const { navigateToPath } = useNavigation();
+
+  useEffect(() => {
+    const loadProjectLists = async () => {
+      try {
+        const path = "TEMPORARY_PATH";
+
+        const projectData = await window.api.loadProjectList(path);
+        setProjects([projectData]);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    loadProjectLists();
+  }, [setProjects]);
 
   const handleProjectClick = project => {
     if (checkProjectPath(project.path)) {
@@ -15,21 +34,17 @@ const ProjectList = ({ showModal }) => {
   };
 
   const handleIconClick = project => {
-    console.log(`삭제할 프로젝트: ${project.name}`);
-  };
-
-  const checkProjectPath = path => {
-    return true;
+    console.log(`삭제할 프로젝트: ${project.projectName}`);
   };
 
   return (
     <PageContentContainer>
       <h1>Project List</h1>
       <ul>
-        {mockData.projects.map((project, index) => (
+        {projects.map((project, index) => (
           <li key={index} onClick={() => handleProjectClick(project)}>
             <div className="project-title">
-              <span>{project.name}</span>
+              <span>{project.projectName}</span>
               <span>{project.path}</span>
             </div>
 

--- a/src/renderer/store/projectStore.js
+++ b/src/renderer/store/projectStore.js
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+const projectStore = create(set => ({
+  projects: [],
+
+  setProjects: projects => set({ projects }),
+  checkProjectPath: path => {
+    return true;
+  }
+}));
+
+export default projectStore;


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- 프로젝트 리스트 로컬 기기의 데이터 파일 데이터 불러오기 기능 구현
- IPC Renderer / Main / preload 작성
- 기능 구현에 필요한 Project 관련 상태 관리 작성


<br />

## 공유 사항(선택사항)

- ProjectList 컴포넌트의 path 경로가 현재 "TEMPORARY_PATH"로 되어 있습니다.
팀원과의 OS 차이로 경로 기준이 다르기 때문에 해당 경로에 목업 데이터 경로로 변경하셔서 작업하셔야 합니다.


<br />

## 체크리스트

- [X] 셀프 리뷰 체크했습니다.
- [X] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [X] base 브랜치명을 체크했습니다.
- [X] 브랜치명을 체크했습니다.
- [X] 코드 컨벤션을 모두 체크했습니다.

<br />
