### PR TITLE
Feat: ProjectList DataDelete-Logic Add

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -53,3 +53,20 @@ ipcMain.handle("get-project-list", async (_, path) => {
     console.error(error);
   }
 });
+
+ipcMain.handle("delete-project-list", async (_, { path, projectName }) => {
+  try {
+    const data = fs.readFileSync(path, "utf-8");
+    let projectData = JSON.parse(data);
+
+    projectData = projectData.filter(
+      project => project.projectName !== projectName
+    );
+
+    fs.writeFileSync(path, JSON.stringify(projectData, null, 2), "utf-8");
+
+    return { updatedProjects: projectData };
+  } catch (error) {
+    console.error(error);
+  }
+});

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("api", {
-  loadProjectList: path => ipcRenderer.invoke("get-project-list", path)
+  loadProjectList: path => ipcRenderer.invoke("get-project-list", path),
+  deleteProjectList: (path, projectName) =>
+    ipcRenderer.invoke("delete-project-list", { path, projectName })
 });

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -16,7 +16,7 @@ const ProjectList = () => {
         const path = "TEMPORARY_PATH";
 
         const projectData = await window.api.loadProjectList(path);
-        setProjects([projectData]);
+        setProjects(projectData);
       } catch (error) {
         console.error(error);
       }
@@ -33,8 +33,17 @@ const ProjectList = () => {
     }
   };
 
-  const handleIconClick = project => {
-    console.log(`삭제할 프로젝트: ${project.projectName}`);
+  const handleIconClick = async project => {
+    try {
+      const path = "TEMPORARY_PATH";
+      const response = await window.api.deleteProjectList(
+        path,
+        project.projectName
+      );
+        setProjects(response.updatedProjects);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- 프로젝트 리스트 로컬 기기의 프로젝트 리스트 데이터 파일에서 사용자가 선택한 파일 데이터 삭제 기능 구현
- 삭제 선택한 프로젝트의 projectName과 데이터파일의 projectName을 비교하여 일치하는 데이터 객체 수정하여 제거.
- 수정된 데이터 파일의 프로젝트 리스트를 화면에 출력 확인 완료
- IPC Renderer / Main / preload 작성


<br />

## 공유 사항(선택사항)

- 이전과 같이 구현 기능의 path 경로가 현재 "TEMPORARY_PATH"로 되어 있습니다.
팀원과의 OS 차이로 경로 기준이 다르기 때문에 해당 경로에 목업 데이터 경로로 변경하셔서 작업하셔야 합니다.

<br />

## 체크리스트

- [x] 셀프 리뷰 체크했습니다.
- [x] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [x] base 브랜치명을 체크했습니다.
- [x] 브랜치명을 체크했습니다.
- [x] 코드 컨벤션을 모두 체크했습니다.

<br />
