### PR TITLE
Feat: OS-directory-setup Add

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",
         "fs": "^0.0.1-security",
+        "os": "^0.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^6.26.0",
@@ -6481,6 +6482,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",
     "fs": "^0.0.1-security",
+    "os": "^0.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^6.26.0",

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,7 +1,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("api", {
-  loadProjectList: path => ipcRenderer.invoke("get-project-list", path),
-  deleteProjectList: (path, projectName) =>
-    ipcRenderer.invoke("delete-project-list", { path, projectName })
+  loadProjectList: () => ipcRenderer.invoke("get-project-list"),
+  deleteProjectList: projectName =>
+    ipcRenderer.invoke("delete-project-list", projectName)
 });

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -13,9 +13,7 @@ const ProjectList = () => {
   useEffect(() => {
     const loadProjectLists = async () => {
       try {
-        const path = "TEMPORARY_PATH";
-
-        const projectData = await window.api.loadProjectList(path);
+        const projectData = await window.api.loadProjectList();
         setProjects(projectData);
       } catch (error) {
         console.error(error);
@@ -35,12 +33,8 @@ const ProjectList = () => {
 
   const handleIconClick = async project => {
     try {
-      const path = "TEMPORARY_PATH";
-      const response = await window.api.deleteProjectList(
-        path,
-        project.projectName
-      );
-        setProjects(response.updatedProjects);
+      const response = await window.api.deleteProjectList(project.projectName);
+      setProjects(response);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- OS (Window / Mac) 별 분기형 Base Directory 설정 기능 추가.
- 초기 폴더가 없는경우 save(세이브파일) / command(명령어) 폴더 생성 기능 추가.
- 기존 Renderer Process에서 전달하던 path 데이터를 Main Process으로 이동하여 코드 간소화.

<br />

## 공유 사항(선택사항)

- 기존에 사용하던 임시 경로가 제거 되었습니다. 
아울러 Renderer에서 전달하던 경로 데이터를 Main에서 관리하는것으로 변경 되었습니다.

<br />

## 체크리스트

- [X] 셀프 리뷰 체크했습니다.
- [X] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [X] base 브랜치명을 체크했습니다.
- [x] 브랜치명을 체크했습니다.
- [x] 코드 컨벤션을 모두 체크했습니다.

<br />
