### PR TITLE
Feat: PackageJSON File Data Load logic Add

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -13,5 +13,7 @@ contextBridge.exposeInMainWorld("api", {
   installProject: projectData =>
     ipcRenderer.invoke("install-project", projectData),
   installDependencies: dependencyData =>
-    ipcRenderer.invoke("install-dependencies", dependencyData)
+    ipcRenderer.invoke("install-dependencies", dependencyData),
+  loadPackageJsonData: projectPath =>
+    ipcRenderer.invoke("get-packageJson-data", projectPath)
 });

--- a/src/renderer/components/Dashboard/DependencyInstall/MyDependencies/index.jsx
+++ b/src/renderer/components/Dashboard/DependencyInstall/MyDependencies/index.jsx
@@ -1,10 +1,43 @@
+import { useEffect } from "react";
 import { MyDependenciesContainer } from "@public/style/DependencyInstall.styles";
 import DependencyList from "@components/common/DependencyList";
-import optionConfig from "@utils/option.config";
 import useUIStore from "@/store/uiStore";
+import useDashboardStore from "@/store/dashboardStore";
 
 const MyDependencies = () => {
-  const { activeTab, setActiveTab } = useUIStore();
+  const { activeTab, setActiveTab } = useUIStore(state => ({
+    activeTab: state.activeTab,
+    setActiveTab: state.setActiveTab
+  }));
+  const {
+    projectPath,
+    dependencies,
+    devDependencies,
+    setDependencies,
+    setDevDependencies
+  } = useDashboardStore(state => ({
+    projectPath: state.projectPath,
+    dependencies: state.dependencies,
+    devDependencies: state.devDependencies,
+    setDependencies: state.setDependencies,
+    setDevDependencies: state.setDevDependencies
+  }));
+
+  useEffect(() => {
+    const loadPackageJson = async () => {
+      if (projectPath) {
+        const loadPackageJson =
+          await window.api.loadPackageJsonData(projectPath);
+
+        if (loadPackageJson) {
+          setDependencies(loadPackageJson.dependencies);
+          setDevDependencies(loadPackageJson.devDependencies);
+        }
+      }
+    };
+
+    loadPackageJson();
+  }, [projectPath, setDependencies, setDevDependencies]);
 
   const handleIconClick = dependency => {
     console.log(`삭제 할 패키지: ${dependency.packageName}`);
@@ -30,13 +63,13 @@ const MyDependencies = () => {
         <li>
           {activeTab === "dependencies" && (
             <DependencyList
-              dependencies={optionConfig.dependencies}
+              dependencies={Object.entries(dependencies)}
               onDelete={handleIconClick}
             />
           )}
           {activeTab === "devDependencies" && (
             <DependencyList
-              dependencies={optionConfig.devDependencies}
+              dependencies={Object.entries(devDependencies)}
               onDelete={handleIconClick}
             />
           )}

--- a/src/renderer/components/common/DependencyList.jsx
+++ b/src/renderer/components/common/DependencyList.jsx
@@ -1,11 +1,15 @@
 import icons from "@public/images";
 
 const DependencyList = ({ dependencies, onDelete }) => {
+  const dependenciesData = dependencies.map(
+    ([index, dependency]) => dependency
+  );
+
   return (
     <ul>
-      {dependencies.map(dependency => (
-        <li key={dependency.packageName}>
-          <span>{dependency.packageName}</span>
+      {dependenciesData.map(dependency => (
+        <li key={dependency.name}>
+          <span>{dependency.name}</span>
           <div className="version-container">
             <span>현재 버전 {dependency.currentVersion}</span>
             <span>최신 버전 {dependency.latestVersion}</span>

--- a/src/renderer/store/dashboardStore.js
+++ b/src/renderer/store/dashboardStore.js
@@ -2,7 +2,9 @@ import { create } from "zustand";
 
 const initialState = {
   folderStructure: null,
-  projectPath: ""
+  projectPath: "",
+  dependencies: {},
+  devDependencies: {}
 };
 
 const useDashboardStore = create(set => ({
@@ -12,7 +14,9 @@ const useDashboardStore = create(set => ({
     set(() => ({
       folderStructure
     })),
-  setProjectPath: projectPath => set({ projectPath })
+  setProjectPath: projectPath => set({ projectPath }),
+  setDependencies: dependencies => set({ dependencies }),
+  setDevDependencies: devDependencies => set({ devDependencies })
 }));
 
 export default useDashboardStore;

--- a/src/renderer/utils/option.config.json
+++ b/src/renderer/utils/option.config.json
@@ -62,7 +62,6 @@
       ]
     }
   ],
-
   "dependenciesSelector": [
     {
       "name": "dotenv",
@@ -115,65 +114,6 @@
     {
       "name": "core-js",
       "type": "boolean"
-    }
-  ],
-  "dependencies": [
-    {
-      "packageName": "react",
-      "currentVersion": "18.3.1",
-      "latestVersion": "18.3.1"
-    },
-    {
-      "packageName": "react-dom",
-      "currentVersion": "18.3.0",
-      "latestVersion": "18.3.1"
-    },
-    {
-      "packageName": "react-router",
-      "currentVersion": "6.26.0",
-      "latestVersion": "6.26.0"
-    },
-    {
-      "packageName": "react-router-dom",
-      "currentVersion": "6.26.0",
-      "latestVersion": "6.26.0"
-    },
-    {
-      "packageName": "redux",
-      "currentVersion": "4.2.1",
-      "latestVersion": "4.2.1"
-    },
-    {
-      "packageName": "styled-components",
-      "currentVersion": "6.1.12",
-      "latestVersion": "6.1.12"
-    },
-    {
-      "packageName": "electron-squirrel-startup",
-      "currentVersion": "1.0.1",
-      "latestVersion": "1.0.1"
-    }
-  ],
-  "devDependencies": [
-    {
-      "packageName": "webpack",
-      "currentVersion": "5.88.1",
-      "latestVersion": "5.88.1"
-    },
-    {
-      "packageName": "babel",
-      "currentVersion": "7.22.10",
-      "latestVersion": "7.22.10"
-    },
-    {
-      "packageName": "eslint",
-      "currentVersion": "8.47.0",
-      "latestVersion": "8.47.0"
-    },
-    {
-      "packageName": "jest",
-      "currentVersion": "29.7.0",
-      "latestVersion": "29.7.0"
     }
   ]
 }


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- option.config 파일에서 프로젝트 의존성 Mock Data 제거.
- 프로젝트 생성 후 Dashboard 이동시 프로젝트 경로 저장
- Dashboard 에서 MyDependencies 페이지 이동시 사용자가 생성한 프로젝트의 package.json 파일
dependencies / devDependencies 부분의 데이터 로드 로직 추가
- DependencyList 로직 일부 수정

<br />

## 공유 사항(선택사항)

- 기존에 프로젝트 생성 시, path 를 비롯한 상태 초기화 문제로 인해 경로가 제대로 이어지지 않던 문제를 
Dashboard 상태 저장소의 projectPath 를 사용하여, CreateProject 재 진입시 이전 데이터는 초기화 하면서, 
프로젝트 생성 경로는 유지하도록 개선하였습니다.

<br />

## 체크리스트

- [x] 셀프 리뷰 체크했습니다.
- [X] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [X] base 브랜치명을 체크했습니다.
- [X] 브랜치명을 체크했습니다.
- [X] 코드 컨벤션을 모두 체크했습니다.

<br />
