### PR TITLE
Perf: Preload / Main Process performance improved

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require("electron");
+import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("api", {
   joinProjectPath: (path, projectName) =>


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- Main Process 동기적 로직들을 await / Promise 를 적용하여 비동기화 시켜 프로세스 작동에 대한 블로킹을 최소화 하였습니다.
- get-packageJson-data  핸들러의 각각의 Promise.all 함수 실행으로 인한 중복문을 하나의 함수로 분리하여 간소화 하였습니다.
- install-dependencies 핸들러의 템플릿 리터럴을 이용한 경로 지정을 path 메서드를 이용하여 동적으로 적용하였습니다. 


<br />

## 공유 사항(선택사항)

- preload의 CJS 방식(require) 모듈 호출 코드를 ESM 방식(import)으로 변경 하였습니다.

<br />

## 체크리스트

- [x] 셀프 리뷰 체크했습니다.
- [x] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [x] base 브랜치명을 체크했습니다.
- [x] 브랜치명을 체크했습니다.
- [x] 코드 컨벤션을 모두 체크했습니다.

<br />
