### PR TITLE
Fix: Project-list path match resolution

### DIFF
--- a/public/style/Project.styles.js
+++ b/public/style/Project.styles.js
@@ -165,9 +165,17 @@ export const PageContentContainer = styled.div`
             width: 40%;
           }
 
+          &:nth-child(2) {
+            width: 20%;
+            font-size: ${({ theme }) => theme.fontSizes.largePlus};
+            color: ${({ theme }) => theme.colors.gray};
+            text-align: center;
+          }
+
           &:last-child {
             min-width: 50%;
             max-width: 100%;
+            text-align: center;
             font-size: ${({ theme }) => theme.fontSizes.largePlus};
             color: ${({ theme }) => theme.colors.sub};
           }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -127,7 +127,11 @@ app.on("window-all-closed", () => {
 });
 
 ipcMain.handle("joined-project-path", (_, basePath, projectName) => {
-  return path.join(basePath, projectName);
+  if (basePath.endsWith(projectName)) {
+    return basePath;
+  } else {
+    return path.join(basePath, projectName);
+  }
 });
 
 ipcMain.handle("get-project-list", async () => {
@@ -158,6 +162,16 @@ ipcMain.handle("delete-project-list", async (_, projectName) => {
     return projectData;
   } catch (error) {
     console.error(error);
+  }
+});
+
+ipcMain.handle("check-project-path", async (_, projectPath) => {
+  try {
+    const exists = fs.existsSync(projectPath);
+    return exists;
+  } catch (error) {
+    console.error("Error checking project path:", error);
+    return false;
   }
 });
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -6,6 +6,8 @@ contextBridge.exposeInMainWorld("api", {
   loadProjectList: () => ipcRenderer.invoke("get-project-list"),
   deleteProjectList: projectName =>
     ipcRenderer.invoke("delete-project-list", projectName),
+  checkProjectPath: projectPath =>
+    ipcRenderer.invoke("check-project-path", projectPath),
   selectFolder: () => ipcRenderer.invoke("setting-path"),
   readDirectory: folderPath => ipcRenderer.invoke("read-directory", folderPath),
   readAllDirectory: folderPath =>

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -12,14 +12,19 @@ import ProjectList from "@components/ProjectList";
 import ErrorModal from "@components/Modal/ErrorModal";
 import DashboardLayout from "@components/Layout/DashboardLayout";
 import PrivateLayout from "@components/Layout/PrivateLayout";
-import useUIStore from "@/store/uiStore";
 
 function App() {
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
-  const { showModal } = useUIStore();
+  const [errorMessage, setErrorMessage] = useState("");
 
   const closeErrorModal = () => {
     setIsErrorModalOpen(false);
+    setErrorMessage("");
+  };
+
+  const openErrorModal = message => {
+    setErrorMessage(message);
+    setIsErrorModalOpen(true);
   };
 
   return (
@@ -31,10 +36,10 @@ function App() {
           <Route path="my-dependencies" element={<DependencyInstall />} />
         </Route>
         <Route path="project" element={<PrivateLayout />}>
-          <Route index element={<ProjectList showModal={showModal} />} />
+          <Route index element={<ProjectList showModal={openErrorModal} />} />
           <Route
             path="project-list"
-            element={<ProjectList showModal={showModal} />}
+            element={<ProjectList showModal={openErrorModal} />}
           />
           <Route path="create-project" element={<CreateProject />} />
         </Route>
@@ -46,7 +51,7 @@ function App() {
       </Routes>
 
       {isErrorModalOpen && (
-        <ErrorModal message="An error occurred" onClose={closeErrorModal} />
+        <ErrorModal message={errorMessage} onClose={closeErrorModal} />
       )}
     </Router>
   );

--- a/src/renderer/components/Dashboard/MyProject/index.jsx
+++ b/src/renderer/components/Dashboard/MyProject/index.jsx
@@ -31,10 +31,13 @@ const ItemList = ({ items = [], setItems }) => {
 };
 
 const MyProject = () => {
-  const { folderStructure, setFolderStructure } = useDashboardStore(state => ({
-    folderStructure: state.folderStructure,
-    setFolderStructure: state.setFolderStructure
-  }));
+  const { folderStructure, dependencies, devDependencies } = useDashboardStore(
+    state => ({
+      folderStructure: state.folderStructure,
+      dependencies: state.dependencies,
+      devDependencies: state.devDependencies
+    })
+  );
 
   return (
     <MyProjectContentContainer>
@@ -55,7 +58,7 @@ const MyProject = () => {
           />
         </>
       ) : (
-        <p>프로젝트가 없습니다.</p>
+        <span>프로젝트가 없습니다.</span>
       )}
     </MyProjectContentContainer>
   );

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -3,6 +3,7 @@ import { PageContentContainer } from "@public/style/Project.styles";
 import { useNavigation } from "@utils/projectUtils";
 import icons from "@public/images";
 import useProjectStore from "@/store/projectStore";
+import useDashboardStore from "@/store/dashboardStore";
 
 const ProjectList = ({ showModal: showModalProp }) => {
   const { projects, setProjects } = useProjectStore();
@@ -25,6 +26,7 @@ const ProjectList = ({ showModal: showModalProp }) => {
   const handleProjectClick = async project => {
     try {
       const isValidPath = await window.api.checkProjectPath(project.path);
+
       if (!isValidPath) {
         showModalProp(`경로를 찾을 수 없습니다: ${project.path}`);
         return;
@@ -34,6 +36,7 @@ const ProjectList = ({ showModal: showModalProp }) => {
         project.path,
         project.projectName
       );
+
       const projectFolderStructure =
         await window.api.readAllDirectory(projectPath);
 
@@ -42,10 +45,29 @@ const ProjectList = ({ showModal: showModalProp }) => {
         return;
       }
 
+      const { dependencies, devDependencies } =
+        await window.api.loadPackageJsonData(projectPath);
+
+      const {
+        setFolderStructure,
+        setProjectPath,
+        setDependencies,
+        setDevDependencies
+      } = useDashboardStore.getState();
+
+      setFolderStructure({
+        name: project.projectName,
+        children: projectFolderStructure
+      });
+
+      setProjectPath(projectPath);
+      setDependencies(dependencies);
+      setDevDependencies(devDependencies);
+
       navigateToPath(`/dashboard/${project.projectName}`);
     } catch (error) {
       showModalProp("프로젝트를 불러오는 중 오류가 발생했습니다.");
-      console.error(error);
+      console.error("Error in handleProjectClick:", error);
     }
   };
 

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -61,9 +61,11 @@ const ProjectList = () => {
           <li key={index} onClick={() => handleProjectClick(project)}>
             <div className="project-title">
               <span>{project.projectName}</span>
+              {project.custom.customName !== "undefined" && (
+                <span>{project.custom.customName}</span>
+              )}
               <span>{project.path}</span>
             </div>
-
             <button>
               <img
                 src={icons.closeIcon}


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

> 작업한 내용을 간략하게 공유해 주세요.
* Project-list에 customName있을경우 같이 보여주는 로직 완료
* Project-list의 path경로와 로컬 기기의 path가 실제로 일치하는지 확인 로직 구현완료
* Project-list path가 서로 불일치 할경우 ErrorModal open 구현완료
* ErrorModal App.js통해서 중앙화 작업 Project-list만 우선작업 완료
* path가 일치하면, readAllDirectory IPC사용하여 대시보드에 해당하는 프로젝트의 navigateToPath projectName에 대한 프로젝트 폴더, 의존성 정보 업로드하여 보여주기 기능 구현 완료

<br />

## 공유 사항(선택사항)

> 팀에 공유할 사항이 있다면 공유해 주세요.
* 의존성 페이지 로딩페이지 + 대시보드의 로딩페이지까지 고려할 사항같습니다. 
프로젝트 구조가 길어질수록 로딩페이지를 통해 사용자 고려를 하는게 좋을듯합니다. 

<br />

## 체크리스트

- [ ] 셀프 리뷰 체크했습니다.
- [ ] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [ ] base 브랜치명을 체크했습니다.
- [ ] 브랜치명을 체크했습니다.
- [ ] 코드 컨벤션을 모두 체크했습니다.

<br />
