### PR TITLE
Fix: Resolve error modal activation when project list is empty

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -73,10 +73,10 @@ const addProjectToJson = async (
       id: projectId,
       projectName: projectName,
       framework: framework,
-      variant: variant || ["undefined"],
+      variant: variant || "undefined",
       path: projectPath,
       custom: {
-        customName: customName || ["undefined"],
+        customName: customName || "undefined",
         dependencies: dependencies
       },
       createdAt: new Date().toISOString()

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -40,7 +40,10 @@ function App() {
         </Route>
         <Route path="project" element={<PrivateLayout />}>
           <Route index element={<ProjectList showModal={openErrorModal} />} />
-          <Route path="project-list" element={<ProjectList />} />
+          <Route
+            path="project-list"
+            element={<ProjectList showModal={openErrorModal} />}
+          />
           <Route path="create-project" element={<CreateProject />} />
         </Route>
 

--- a/src/renderer/components/Modal/ErrorModal.jsx
+++ b/src/renderer/components/Modal/ErrorModal.jsx
@@ -1,13 +1,9 @@
-import { useNavigate } from "react-router-dom";
 import ButtonBox from "@components/common/ButtonBox";
 import { ModalBackground, ModalContainer } from "@public/style/Modal.styles";
 
 const ErrorModal = ({ message, onClose }) => {
-  const navigate = useNavigate();
-
   const handleClose = () => {
     onClose();
-    navigate(-1);
   };
 
   return (

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -33,7 +33,7 @@ const ProjectList = ({ showModal: showModalProp }) => {
       const isValidPath = await window.api.checkProjectPath(project.path);
 
       if (!isValidPath) {
-        showModalProp(`경로를 찾을 수 없습니다: ${project.path}`);
+        showModalProp(`경로를 찾을 수 없습니다`);
         return;
       }
 


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

> 작업한 내용을 간략하게 공유해 주세요.
* project-list 에서 customName이 undefined의 조건문이있으나, undefined이 보여지는 부분 문제 해결
* project-list에서 경로가 실제 경로와 맞지않을때 ErrorModal 제대로 보이지않은 부분 해결
* ErrorModal 활성화시 close 클릭시에 이전 페이지로 가거나 대시보드로 넘어가는 edge case 해결

<br />

## 공유 사항(선택사항)

> 팀에 공유할 사항이 있다면 공유해 주세요.

<br />

## 체크리스트

- [x] 셀프 리뷰 체크했습니다.
- [x] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [x] base 브랜치명을 체크했습니다.
- [x] 브랜치명을 체크했습니다.
- [x] 코드 컨벤션을 모두 체크했습니다.

<br />
