### PR TITLE
Feat: Project Start / End Controller logic Add

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "child_process": "^1.0.2",
         "electron-squirrel-startup": "^1.0.1",
         "fs": "^0.0.1-security",
+        "open": "^10.1.0",
         "os": "^0.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2669,6 +2670,20 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3251,6 +3266,32 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -3286,6 +3327,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -5551,6 +5603,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5596,6 +5662,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -5673,6 +5756,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isbinaryfile": {
@@ -6477,6 +6574,23 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7521,6 +7635,17 @@
         "@rollup/rollup-win32-ia32-msvc": "4.20.0",
         "@rollup/rollup-win32-x64-msvc": "4.20.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "child_process": "^1.0.2",
     "electron-squirrel-startup": "^1.0.1",
     "fs": "^0.0.1-security",
+    "open": "^10.1.0",
     "os": "^0.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -21,5 +21,7 @@ contextBridge.exposeInMainWorld("api", {
   addInstallDependencies: dependencyData =>
     ipcRenderer.invoke("add-install-dependencies", dependencyData),
   uninstallDependencies: dependencyData =>
-    ipcRenderer.invoke("uninstall-dependencies", dependencyData)
+    ipcRenderer.invoke("uninstall-dependencies", dependencyData),
+  runProject: projectPath => ipcRenderer.invoke("run-project", projectPath),
+  endProject: processId => ipcRenderer.invoke("end-project", processId)
 });

--- a/src/renderer/components/Dashboard/MyProject/ProjectController.jsx
+++ b/src/renderer/components/Dashboard/MyProject/ProjectController.jsx
@@ -1,12 +1,35 @@
-import { useState } from "react";
 import { ProjectControllerContainer } from "@public/style/Dashboard.styles";
+import useUIStore from "@/store/uiStore";
+import useDashboardStore from "@/store/dashboardStore";
 
 const ProjectController = () => {
-  const [isChecked, setIsChecked] = useState(false);
+  const { isChecked, setIsChecked } = useUIStore(state => ({
+    isChecked: state.isChecked,
+    setIsChecked: state.setIsChecked
+  }));
+  const { projectPath, processId, setProcessId } = useDashboardStore(state => ({
+    projectPath: state.projectPath,
+    processId: state.processId,
+    setProcessId: state.setProcessId
+  }));
 
-  const handleToggleSwitch = () => {
+  const handleProjectOnOff = async () => {
+    if (!isChecked) {
+      try {
+        const runningProcess = await window.api.runProject(projectPath);
+        setProcessId(runningProcess.runProcessId);
+      } catch (error) {
+        console.error(error);
+      }
+    } else {
+      try {
+        await window.api.endProject(processId);
+        setProcessId(null);
+      } catch (error) {
+        console.error(error);
+      }
+    }
     setIsChecked(!isChecked);
-    console.log(isChecked ? "프로젝트 실행중" : "프로젝트 종료");
   };
 
   return (
@@ -18,7 +41,7 @@ const ProjectController = () => {
           className="project-controller-button"
           type="checkbox"
           checked={isChecked}
-          onChange={handleToggleSwitch}
+          onChange={handleProjectOnOff}
         ></input>
       </label>
     </ProjectControllerContainer>

--- a/src/renderer/store/dashboardStore.js
+++ b/src/renderer/store/dashboardStore.js
@@ -4,7 +4,8 @@ const initialState = {
   folderStructure: null,
   projectPath: "",
   dependencies: {},
-  devDependencies: {}
+  devDependencies: {},
+  processId: null
 };
 
 const useDashboardStore = create(set => ({
@@ -15,7 +16,8 @@ const useDashboardStore = create(set => ({
   },
   setProjectPath: projectPath => set({ projectPath }),
   setDependencies: dependencies => set({ dependencies }),
-  setDevDependencies: devDependencies => set({ devDependencies })
+  setDevDependencies: devDependencies => set({ devDependencies }),
+  setProcessId: processId => set({ processId })
 }));
 
 export default useDashboardStore;

--- a/src/renderer/store/uiStore.js
+++ b/src/renderer/store/uiStore.js
@@ -30,7 +30,8 @@ const initialState = {
     isLoading: false,
     loadingMessages: [],
     currentLoadingMessageIndex: 0
-  }
+  },
+  isChecked: false
 };
 
 const useUIStore = create(set => ({
@@ -126,7 +127,9 @@ const useUIStore = create(set => ({
       }
     })),
 
-  resetUIState: () => set(initialState)
+  resetUIState: () => set(initialState),
+
+  setIsChecked: isChecked => set({ isChecked })
 }));
 
 export default useUIStore;


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 작업 내용

- Dahsboard 컴포넌트 페이지 현재 지정된 프로젝트 실행 / 종료 기능 구현
- JS / React Project 실행 / 종료 테스트 확인 완료

<br />

## 공유 사항(선택사항)

- 프로젝트 실행 자체는 터미널 명령어 전달만으로 진행이 되지만 웹 브라우저를 출력해 주는 작업은 추가적인 패키지 모듈
(open 라이브러리)이 필요 하여 모듈을 추가하였습니다.
- 기존의 exec 메서드를 이용한 명령어 전달로는 'run-project' 핸들러가 작동하지 않는 문제가 발생하여 spawn 메서드를 추가로 호출하여 구성하였습니다.
- Electron의 Main Process가 Node JS 환경이기 때문에 open 모듈을 import를 적용하여 호출할 경우 ESM 관련 오류가 
출력되는 문제로 open 모듈을 예외적으로 **Dynamic import** 방법을 적용하여 작성 하였습니다.
- 각각의 CLI를 이용한 생성 프로젝트의 Package.json의 실행 명령어가 다르기 때문에 프로젝트 실행 / 종료 기능은 
현재 VITE 기반 설치 프로젝트만 작동하도록 구현되었습니다.
- Vanilla Javascript를 제외한 React / Vue 등 라이브러리 기반 프로젝트는 'npm install' 명령어를 실행 명령어 이전에 
입력되어야 정상 작동하여 불가피하게 실행 이전에 'npm install' 명령어가 입력되도록 구성하였습니다.
- 위의 'npm install' 명령어 실행과 실행 / 종료 기능 동작 시 프로젝트 작동의 딜레이가 존재하여 프로젝트 실행 / 종료 
기능 시에도 Loading 컴포넌트가 필요하게 되었습니다.

<br />

## 체크리스트

- [x] 셀프 리뷰 체크했습니다.
- [X] 가장 최신 브랜치를 pull 하여 체크했습니다.
- [X] base 브랜치명을 체크했습니다.
- [X] 브랜치명을 체크했습니다.
- [X] 코드 컨벤션을 모두 체크했습니다.

<br />
